### PR TITLE
Fix initializer order for Error() object.

### DIFF
--- a/src/Common/Error.h
+++ b/src/Common/Error.h
@@ -51,7 +51,7 @@ class Error
 
     protected:
         // protected constructor so this class must be inherited from
-        Error() : m_szError(0), m_bFatal(false) { }
+        Error() : m_bFatal(false), m_szError(0) { }
 
         // protected deconstructor
        ~Error() { delete[] m_szError; }


### PR DESCRIPTION
Resolves the following Clang warning.

```
clang++ -g -O2 -Wall -I../../src -I../../src/Common/Linux -I../..src/Linux -o ../../src/Common/OpenXDK.o -c ../../src/Common/OpenXDK.cpp
In file included from ../../src/Common/OpenXDK.cpp:34:
In file included from ../../src/Common/Xbe.h:37:
../../src/Common/Error.h:54:19: warning: field 'm_szError' will be initialized
      after field 'm_bFatal' [-Wreorder]
        Error() : m_szError(0), m_bFatal(false) { }
                  ^
1 warning generated.
```
